### PR TITLE
Cancel sender connection correctly on timeout and remove newtonsoft json dependency

### DIFF
--- a/src/ISender.cs
+++ b/src/ISender.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,11 @@ namespace ZabbixSender.Async
     /// </summary>
     public interface ISender
     {
+        /// <summary>
+        /// The host name or IP address of Zabbix server or proxy.
+        /// </summary>
+        public String ZabbixServer { get; }
+
         /// <summary>
         /// Send an array of data items.
         /// </summary>

--- a/src/JsonUnixDateTime.cs
+++ b/src/JsonUnixDateTime.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ZabbixSender.Async;
+
+public class JsonUnixDateTime : JsonConverter<DateTimeOffset>
+{
+    public override DateTimeOffset Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var timestamp = reader.GetInt64();
+        return DateTimeOffset.FromUnixTimeSeconds(timestamp);
+    }
+
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        DateTimeOffset v,
+        JsonSerializerOptions options) =>
+        writer.WriteNumberValue(v.ToUnixTimeSeconds());
+}

--- a/src/SendData.cs
+++ b/src/SendData.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net;
+using System.Text.Json.Serialization;
 
 namespace ZabbixSender.Async
 {
@@ -27,6 +29,7 @@ namespace ZabbixSender.Async
         /// <summary>
         /// A timestamp for the provided value. Leave null for ongoing values.
         /// </summary>
-        public DateTime? Clock { get; set; }
+        [JsonConverter(typeof(JsonUnixDateTime))]
+        public DateTimeOffset? Clock { get; set; }
     }
 }

--- a/src/Sender.cs
+++ b/src/Sender.cs
@@ -9,7 +9,7 @@ namespace ZabbixSender.Async
     /// A class to send data to Zabbix. Be sure, that all used host names and items are configured.
     /// All the items should have type "Zabbix trapper" to support Zabbix sender data flow.
     /// </summary>
-    public class Sender : SenderSkeleton
+    public class Sender : SenderSkeleton, ISender
     {
         /// <summary>
         /// Initializes a new instance of the ZabbixSender.Async.Sender class.

--- a/src/Sender.cs
+++ b/src/Sender.cs
@@ -38,18 +38,20 @@ namespace ZabbixSender.Async
 
         private static Func<CancellationToken, Task<TcpClient>> CreateTcpClient(string zabbixServer, int port, int timeout, int bufferSize)
         {
-            var tcpClient = new TcpClient
-            {
-                SendTimeout = timeout,
-                ReceiveTimeout = timeout,
-                SendBufferSize = bufferSize,
-                ReceiveBufferSize = bufferSize
-            };
-
             return async cancellationToken =>
             {
-                await tcpClient.ConnectAsync(zabbixServer, port)
-                    .WithTimeout(timeout, cancellationToken);
+                var tcpClient = new TcpClient
+                {
+                    SendTimeout = timeout,
+                    ReceiveTimeout = timeout,
+                    SendBufferSize = bufferSize,
+                    ReceiveBufferSize = bufferSize
+                };
+                
+                var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                source.CancelAfter(timeout);
+
+                await tcpClient.ConnectAsync(zabbixServer, port, source.Token);
 
                 return tcpClient;
             };

--- a/src/SenderSkeleton.cs
+++ b/src/SenderSkeleton.cs
@@ -9,7 +9,7 @@ namespace ZabbixSender.Async
     /// <summary>
     /// A basic class for sending datato Zabbix, which allows custom setup for TcpClient and Formatter.
     /// </summary>
-    public class SenderSkeleton : ISender
+    public class SenderSkeleton
     {
         private readonly Func<CancellationToken, Task<TcpClient>> tcpClientFactory;
         private readonly Func<IFormatter> formatterFactory;

--- a/src/ZabbixDataMessage.cs
+++ b/src/ZabbixDataMessage.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ZabbixSender.Async;
+
+public record ZabbixDataMessage(string Request, IEnumerable<SendData> Data, DateTimeOffset Clock)
+{
+    public override string ToString()
+    {
+        return $"{{ Request = {Request}, Data = {Data}, Clock = {Clock} }}";
+    }
+
+    [JsonConverter(typeof(JsonUnixDateTime))]
+    public DateTimeOffset Clock { get; init; } = Clock;
+}

--- a/src/ZabbixSender.Async.csproj
+++ b/src/ZabbixSender.Async.csproj
@@ -23,11 +23,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="..\license.txt">
       <Pack>True</Pack>

--- a/src/ZabbixSender.Async.xml
+++ b/src/ZabbixSender.Async.xml
@@ -91,6 +91,11 @@
             Zabbix data sender.
             </summary>
         </member>
+        <member name="P:ZabbixSender.Async.ISender.ZabbixServer">
+            <summary>
+            The host name or IP address of Zabbix server or proxy.
+            </summary>
+        </member>
         <member name="M:ZabbixSender.Async.ISender.Send(ZabbixSender.Async.SendData[])">
             <summary>
             Send an array of data items.

--- a/src/ZabbixSender.Async.xml
+++ b/src/ZabbixSender.Async.xml
@@ -16,7 +16,7 @@
             </summary>
             <param name="bufferSize">Stream buffer size.</param>
         </member>
-        <member name="M:ZabbixSender.Async.Formatter.#ctor(Newtonsoft.Json.JsonSerializerSettings,System.Int32)">
+        <member name="M:ZabbixSender.Async.Formatter.#ctor(System.Text.Json.JsonSerializerOptions,System.Int32)">
             <summary>
             Initializes a new instance of the ZabbixSender.Async.Formatter class.
             </summary>


### PR DESCRIPTION
On connection timeout the following error occurs:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Net.Sockets.TcpClient.ConnectAsync(String host, Int32 port)
   at ZabbixSender.Async.Sender.<>c__DisplayClass7_0.<<CreateTcpClient>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at ZabbixSender.Async.SenderSkeleton.Send(IEnumerable`1 data, CancellationToken cancellationToken)
   at X4BFlow.Main.Metrics.ZabbixMetricsReporter.FlushAsync(MetricsDataValueSource metricsData, CancellationToken cancellationToken) in /home/runner/work/**/Metrics/ZabbixMetricsReporter.cs:line 87
   at App.Metrics.Internal.DefaultMetricsReportRunner.FlushMetrics(IMetrics metrics, CancellationToken cancellationToken, IReportMetrics reporter)
```

This is becase a TcpClient that fails during connection can not be reused.

I've also replaced the Newtonsoft Json dependency with the integrated System.Text.Json.